### PR TITLE
Skips input[type=password] when compiling form values for tracking

### DIFF
--- a/spec/FormDataSpec.js
+++ b/spec/FormDataSpec.js
@@ -14,6 +14,21 @@ describe("GaEventTrack.FormSubmit", function() {
     });
   });
 
+  describe("when loading the password form fixture", function() {
+    beforeEach(function() {
+      loadFixtures('form_with_password.html');
+      GaTrackFormData = new GaEventTrack.FormSubmit($('form'));
+    });
+
+    it("should have a query value of Kerouac", function() {
+      expect(GaTrackFormData.inputs['request']).toEqual('Kerouac');
+    });
+
+    it("should not have a privateval password input", function() {
+      expect(GaTrackFormData.inputs.privateval).not.toBeDefined();
+    });
+  });
+
   describe("when loading the book form fixture", function() {
     beforeEach(function() {
       loadFixtures('book_form.html');

--- a/spec/FormSpec.js
+++ b/spec/FormSpec.js
@@ -52,6 +52,24 @@ describe("Forms", function() {
     });
   });
 
+  describe("when a form contains a password field", function() {
+    beforeEach(function() {
+      loadFixtures('form_with_password.html');
+      $.ga_event_track_forms('forms');
+    });
+
+    it("should push event to GA excluding the password", function(){
+      var spyEvent = spyOnEvent($('body.ga-track-forms form'), 'submit');
+
+      var plabel = ['_trackEvent', 'Forms', 'Submit', {form: "passwordform", request: "Kerouac"}];
+      $('form').submit(function(event){
+        event.preventDefault();
+        expect(spyEvent).toHaveBeenTriggered();
+        expect(_gaq).toEqual(plabel);
+      });
+    });
+  });
+
   describe("when no forms to track has been loaded", function() {
     beforeEach(function() {
       loadFixtures('no_forms_to_track.html');

--- a/spec/javascripts/fixtures/form_with_password.html
+++ b/spec/javascripts/fixtures/form_with_password.html
@@ -1,0 +1,6 @@
+<body class="ga-track-forms" data-media="large">
+  <form name="passwordform">
+    <input name="request" type="text" value="Kerouac">
+    <input type="password" name="privateval" value="secretpassword">
+  </form>
+</body>

--- a/src/jquery.ga-event-track.form-submit.js
+++ b/src/jquery.ga-event-track.form-submit.js
@@ -41,7 +41,11 @@
 
     // Private: Capture input name, or default to input type
     var inputName = function(input) {
-          return input.attr('name') || input.attr('type'); };
+          return input.attr('name') || inputType(input); };
+
+    // Private: Capture input type
+    var inputType = function(input) {
+          return input.attr('type'); };
 
     // Private: Capture input value, handle radio buttons properly
     var inputValue = function(input) {
@@ -77,7 +81,9 @@
           var $formData = {};
           $(':input', $form).each(function() {
             var $input = $(this);
-            $formData[inputName($input)] = inputValue($input);
+            if (inputType($input) != 'password') {
+              $formData[inputName($input)] = inputValue($input);
+            }
           });
           return $formData; };
 


### PR DESCRIPTION
[This issue with Mixpanel](https://www.reddit.com/r/analytics/comments/7ukw4n/mixpanel_js_library_has_been_harvesting_passwords/) got me thinking about guarding against this problem proactively, in case ga-event-track is ever carelessly applied to something with secure input fields.